### PR TITLE
feat: add read go.mod as bytes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
+# ignore the binary, but not the folder
 gograveyard
+!cmd/gograveyard
+
 coverage.out

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,8 +5,6 @@ linters:
     - exhaustruct
     # forbids fmt.Print.* and others
     - forbidigo
-    # no global variables
-    - gochecknoglobals
     # specify parallel on every test
     - paralleltest
     # tests in a separate package

--- a/cmd/gograveyard/main.go
+++ b/cmd/gograveyard/main.go
@@ -18,24 +18,25 @@ var (
 	errTooManyFiles = errors.New("too many arguments, only one go.mod allowed")
 )
 
-func printHelp() {
-	fmt.Println("The Go project undertaker: check go.mod dependency's health")
-	fmt.Println("")
-	fmt.Println("Usage:")
-	fmt.Println("  gograveyard [flags] [command]")
-	fmt.Println("")
-	fmt.Println("Available Commands:")
-	fmt.Println("  help     Print this help")
-	fmt.Println("  parse    Parse a provided go.mod")
-	fmt.Println("  version  Print current version")
-	fmt.Println("")
-	fmt.Println("Flags:")
-	fmt.Println("  --help, -h   help for gograveyard")
-	fmt.Println("  --json, -j   output final report in JSON")
+func helpString() string {
+	return `The Go project undertaker: check go.mod dependency's health
+
+Usage:
+  gograveyard [flags] [command]
+
+Available Commands:
+  help     Print this help
+  parse    Parse a provided go.mod
+  version  Print current version
+
+Flags:
+  --help, -h   help for gograveyard
+  --json, -j   output final report in JSON
+`
 }
 
-func printVersion() {
-	fmt.Printf("gograveyard (%s)\n", version)
+func versionString() string {
+	return fmt.Sprintf("gograveyard (%s)\n", version)
 }
 
 func parse(args []string) error {
@@ -59,7 +60,9 @@ func parse(args []string) error {
 }
 
 func main() {
-	flag.Usage = printHelp
+	flag.Usage = func() {
+		fmt.Print(helpString())
+	}
 
 	var json bool
 	flag.BoolVar(&json, "json", false, "output final report in JSON")
@@ -70,8 +73,8 @@ func main() {
 
 	// Parse the arguments, everything after the flags
 	if len(os.Args) <= flag.NFlag()+1 {
-		fmt.Printf("no subcommand specified")
-		printHelp()
+		fmt.Print("no subcommand specified\n")
+		fmt.Print(helpString())
 		os.Exit(1)
 	}
 
@@ -82,7 +85,7 @@ func main() {
 
 	switch subcommand {
 	case "help":
-		printHelp()
+		fmt.Print(helpString())
 	case "parse":
 		err := parse(args)
 		if err != nil {
@@ -90,10 +93,10 @@ func main() {
 			os.Exit(1)
 		}
 	case "version":
-		printVersion()
+		fmt.Print(versionString())
 	default:
-		fmt.Printf("unknown subcommand")
-		printHelp()
+		fmt.Printf("unknown subcommand: '%s'\n", subcommand)
+		fmt.Print(helpString())
 		os.Exit(1)
 	}
 }

--- a/cmd/gograveyard/main.go
+++ b/cmd/gograveyard/main.go
@@ -5,6 +5,8 @@ import (
 	"flag"
 	"fmt"
 	"os"
+
+	"github.com/goreapers/gograveyard"
 )
 
 const (
@@ -12,8 +14,8 @@ const (
 )
 
 var (
-	json           bool
-	ErrNoURLorPath = errors.New("need a URL or path to undertake")
+	errNoFileArg    = errors.New("a path to go.mod is required")
+	errTooManyFiles = errors.New("too many arguments, only one go.mod allowed")
 )
 
 func printHelp() {
@@ -24,7 +26,7 @@ func printHelp() {
 	fmt.Println("")
 	fmt.Println("Available Commands:")
 	fmt.Println("  help     Print this help")
-	fmt.Println("  parse    Parse a provided URL or path")
+	fmt.Println("  parse    Parse a provided go.mod")
 	fmt.Println("  version  Print current version")
 	fmt.Println("")
 	fmt.Println("Flags:")
@@ -38,12 +40,20 @@ func printVersion() {
 
 func parse(args []string) error {
 	if len(args) == 0 {
-		return ErrNoURLorPath
+		return errNoFileArg
+	}
+	if len(args) > 1 {
+		return errTooManyFiles
 	}
 
-	for i, arg := range args {
-		fmt.Printf("  %d: %s\n", i, arg)
+	goModBytes, err := gograveyard.GoModBytes(args[0])
+	if err != nil {
+		return fmt.Errorf("unable to read '%s': %w", args[0], err)
 	}
+
+	//nolint:godox
+	// TODO: replace me with parsing the bytes
+	fmt.Println(string(goModBytes))
 
 	return nil
 }
@@ -51,6 +61,7 @@ func parse(args []string) error {
 func main() {
 	flag.Usage = printHelp
 
+	var json bool
 	flag.BoolVar(&json, "json", false, "output final report in JSON")
 	flag.BoolVar(&json, "j", false, "output final report in JSON")
 

--- a/cmd/gograveyard/main_test.go
+++ b/cmd/gograveyard/main_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	if err := parse([]string{"../../go.mod"}); err != nil {
+		t.Fail()
+	}
+}
+
+func TestParse_NoArgs(t *testing.T) {
+	if err := parse([]string{}); !errors.Is(err, errNoFileArg) {
+		t.Fail()
+	}
+}
+
+func TestParse_TooManyArgs(t *testing.T) {
+	if err := parse([]string{"fake", "invalid"}); !errors.Is(err, errTooManyFiles) {
+		t.Fail()
+	}
+}
+
+func TestParse_DoesNotExist(t *testing.T) {
+	if err := parse([]string{"fake"}); err == nil {
+		t.Fail()
+	}
+}
+
+func TestHelp(t *testing.T) {
+	help := helpString()
+
+	if help == "" {
+		t.Fatalf("all help output is missing")
+	}
+
+	if !strings.Contains(help, "  help") {
+		t.Fatalf("help missing")
+	}
+
+	if !strings.Contains(help, "  parse") {
+		t.Fatalf("parse missing")
+	}
+
+	if !strings.Contains(help, "  version") {
+		t.Fatalf("version missing")
+	}
+
+	if !strings.Contains(help, "--help") {
+		t.Fatalf("help flag missing")
+	}
+
+	if !strings.Contains(help, "--json") {
+		t.Fatalf("json flag missing")
+	}
+}
+
+func TestVersion(t *testing.T) {
+	version := versionString()
+
+	if version == "" {
+		t.Fatalf("version is empty")
+	}
+
+	if !strings.HasPrefix(version, "gograveyard (v") {
+		t.Fatalf("version not prefixed correctly: '%s'", version)
+	}
+
+	if strings.Count(version, ".") != 2 {
+		t.Fatalf("version does not contain major & minor separator: '%s'", version)
+	}
+}

--- a/file.go
+++ b/file.go
@@ -1,0 +1,15 @@
+package gograveyard
+
+import (
+	"fmt"
+	"os"
+)
+
+func GoModBytes(pathToGoMod string) ([]byte, error) {
+	bytes, err := os.ReadFile(pathToGoMod)
+	if err != nil {
+		return nil, fmt.Errorf("failed reading file: %w", err)
+	}
+
+	return bytes, nil
+}

--- a/file_test.go
+++ b/file_test.go
@@ -1,0 +1,17 @@
+package gograveyard
+
+import (
+	"testing"
+)
+
+func TestGoModRead(t *testing.T) {
+	if _, err := GoModBytes("go.mod"); err != nil {
+		t.Fail()
+	}
+}
+
+func TestGoModRead_doesNotExist(t *testing.T) {
+	if _, err := GoModBytes("FileDoesNotExist"); err == nil {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
This adds the ability to read a file and return it as bytes.

It also refactors the gograveyard cmd to allow for some testing of some of the functions there. 

fixes: #13