### PR TITLE
feat: Parse go.mod

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,8 @@ linters:
     - varnamelen
     # whitespace linter
     - wsl
+    # Linter requires a new line before return and branch statements
+    - nlreturn
 linters-settings:
   lll:
     line-length: 100

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,8 +13,6 @@ linters:
     - varnamelen
     # whitespace linter
     - wsl
-    # find structs that have uninitialized fields
-    - exhaustivestruct
 linters-settings:
   lll:
     line-length: 100

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,8 @@ linters:
     - varnamelen
     # whitespace linter
     - wsl
+    # find structs that have uninitialized fields
+    - exhaustivestruct
 linters-settings:
   lll:
     line-length: 100

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,8 @@ linters:
     - wsl
     # Linter requires a new line before return and branch statements
     - nlreturn
+    # Linter requires periods at end of comments
+    - godot
 linters-settings:
   lll:
     line-length: 100

--- a/cmd/gograveyard/main.go
+++ b/cmd/gograveyard/main.go
@@ -52,9 +52,13 @@ func parse(args []string) error {
 		return fmt.Errorf("unable to read '%s': %w", args[0], err)
 	}
 
-	//nolint:godox
-	// TODO: replace me with parsing the bytes
-	fmt.Println(string(goModBytes))
+	modFile, err := gograveyard.Parse(goModBytes)
+	if err != nil {
+		return fmt.Errorf("failed to parse: %w", err)
+	}
+
+	fmt.Printf("This modfile has %d direct dependencies and %d indirect dependencies \n",
+		len(modFile.Direct), len(modFile.Indirect))
 
 	return nil
 }

--- a/modfile.go
+++ b/modfile.go
@@ -13,9 +13,8 @@ type ModFile struct {
 }
 
 type Module struct {
-	Path     string
-	Version  string
-	Indirect bool
+	Path    string
+	Version string
 }
 
 func Parse(data []byte) (*ModFile, error) {

--- a/modfile.go
+++ b/modfile.go
@@ -25,36 +25,44 @@ func Parse(data []byte) (*ModFile, error) {
 	var f ModFile
 
 	for scanner.Scan() {
-		switch s := scanner.Text(); s {
+		switch scanner.Text() {
 		case "require (":
 			require = true
+
+			continue
 		case ")":
 			require = false
-		default:
-			if !require {
-				continue
-			}
 
-			// If in a require section, parse the module
-			// A module is required to have a path and version, the "indirect" comment is optional
-			var mod Module
-			m := strings.Split(strings.TrimSpace(s), " ")
-			const pathAndVersion = 2
-			if len(m) == pathAndVersion {
-				mod.Path = m[0]
-				mod.Version = m[1]
-			}
-			var indirect bool
-			if len(m) == 4 && fmt.Sprintf("%s %s", m[2], m[3]) == "// indirect" {
-				indirect = true
-			}
-			if len(m) >= pathAndVersion {
-				if indirect {
-					f.Indirect = append(f.Indirect, &mod)
-				} else {
-					f.Direct = append(f.Direct, &mod)
-				}
-			}
+			continue
+		}
+
+		if !require {
+			continue
+		}
+
+		// If in a require section, parse the module
+		// A module is required to have a path and version, the "indirect" comment is optional
+		var mod Module
+		m := strings.Split(strings.TrimSpace(scanner.Text()), " ")
+		const pathAndVersion = 2
+		if len(m) == pathAndVersion {
+			mod.Path = m[0]
+			mod.Version = m[1]
+		}
+		// Skip if invalid module, missing required path or version
+		if len(m) < pathAndVersion {
+			continue
+		}
+
+		var indirect bool
+		if len(m) == 4 && fmt.Sprintf("%s %s", m[2], m[3]) == "// indirect" {
+			indirect = true
+		}
+
+		if indirect {
+			f.Indirect = append(f.Indirect, &mod)
+		} else {
+			f.Direct = append(f.Direct, &mod)
 		}
 	}
 

--- a/modfile.go
+++ b/modfile.go
@@ -124,7 +124,6 @@ func parseReplace(line string, replace map[string]replaceInfo) {
 func replaceMods(mods []*Module, replace map[string]replaceInfo) {
 	for _, m := range mods {
 		if val, ok := replace[m.Path]; ok {
-			// If the replace directive specifies a version, only update paths with a matching version
 			if val.Originalversion != "" && val.Originalversion != m.Version {
 				continue
 			}

--- a/modfile.go
+++ b/modfile.go
@@ -92,6 +92,8 @@ func parseReplace(line string, replace map[string]replaceInfo) {
 	var originalPath string
 	var info replaceInfo
 
+	const middle = 3
+
 	for i, r := range replaceTxt {
 		if r == "replace" || r == "=>" {
 			continue
@@ -99,7 +101,7 @@ func parseReplace(line string, replace map[string]replaceInfo) {
 
 		if VerifySemanticVersion(r) {
 			// The version for the path on the left side of `=>` will have an index less than 3
-			if i < 3 {
+			if i < middle {
 				info.Originalversion = r
 				continue
 			}
@@ -108,7 +110,7 @@ func parseReplace(line string, replace map[string]replaceInfo) {
 			continue
 		}
 
-		if i < 3 {
+		if i < middle {
 			originalPath = r
 			continue
 		}

--- a/modfile.go
+++ b/modfile.go
@@ -1,0 +1,62 @@
+package gograveyard
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+type ModFile struct {
+	Direct   []*Module
+	Indirect []*Module
+}
+
+type Module struct {
+	Path     string
+	Version  string
+	Indirect bool
+}
+
+func Parse(data []byte) (*ModFile, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+
+	var require bool
+	var f ModFile
+
+	for scanner.Scan() {
+		switch s := scanner.Text(); s {
+		case "require (":
+			require = true
+		case ")":
+			require = false
+		default:
+			if !require {
+				continue
+			}
+
+			// If in a require section, parse the module
+			// A module is required to have a path and version, the "indirect" comment is optional
+			var mod Module
+			m := strings.Split(strings.TrimSpace(s), " ")
+			const pathAndVersion = 2
+			if len(m) == pathAndVersion {
+				mod.Path = m[0]
+				mod.Version = m[1]
+			}
+			var indirect bool
+			if len(m) == 4 && fmt.Sprintf("%s %s", m[2], m[3]) == "// indirect" {
+				indirect = true
+			}
+			if len(m) >= pathAndVersion {
+				if indirect {
+					f.Indirect = append(f.Indirect, &mod)
+				} else {
+					f.Direct = append(f.Direct, &mod)
+				}
+			}
+		}
+	}
+
+	return &f, nil
+}

--- a/modfile.go
+++ b/modfile.go
@@ -42,16 +42,16 @@ func Parse(data []byte) (*ModFile, error) {
 
 		// If in a require section, parse the module
 		// A module is required to have a path and version, the "indirect" comment is optional
-		var mod Module
 		m := strings.Split(strings.TrimSpace(scanner.Text()), " ")
 		const pathAndVersion = 2
-		if len(m) == pathAndVersion {
-			mod.Path = m[0]
-			mod.Version = m[1]
-		}
 		// Skip if invalid module, missing required path or version
 		if len(m) < pathAndVersion {
 			continue
+		}
+
+		mod := Module{
+			Path:    m[0],
+			Version: m[1],
 		}
 
 		var indirect bool

--- a/modfile_test.go
+++ b/modfile_test.go
@@ -1,0 +1,51 @@
+package gograveyard
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		filename          string
+		expectedDirect    int
+		expectedIndirects int
+	}{
+		{
+			filename:          "simple.go.mod",
+			expectedDirect:    5,
+			expectedIndirects: 1,
+		},
+		{
+			filename:          "telegraf.go.mod",
+			expectedDirect:    182,
+			expectedIndirects: 243,
+		},
+	}
+
+	for _, test := range tests {
+		data, err := GoModBytes(filepath.Join("testdata", test.filename))
+		if err != nil {
+			t.Log(err)
+			t.Fail()
+		}
+
+		modFile, err := Parse(data)
+		if err != nil {
+			t.Log(err)
+			t.Fail()
+		}
+
+		if len(modFile.Direct) != test.expectedDirect {
+			t.Logf("Expected %d dependencies but received %d",
+				test.expectedDirect, len(modFile.Direct))
+			t.Fail()
+		}
+
+		if len(modFile.Indirect) != test.expectedIndirects {
+			t.Logf("Expected %d dependencies but received %d",
+				test.expectedDirect, len(modFile.Indirect))
+			t.Fail()
+		}
+	}
+}

--- a/modfile_test.go
+++ b/modfile_test.go
@@ -26,26 +26,69 @@ func TestParse(t *testing.T) {
 	for _, test := range tests {
 		data, err := GoModBytes(filepath.Join("testdata", test.filename))
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Fatal(err)
 		}
 
 		modFile, err := Parse(data)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Fatal(err)
 		}
 
 		if len(modFile.Direct) != test.expectedDirect {
-			t.Logf("Expected %d dependencies but received %d",
+			t.Fatalf("Expected %d dependencies but received %d",
 				test.expectedDirect, len(modFile.Direct))
-			t.Fail()
 		}
 
 		if len(modFile.Indirect) != test.expectedIndirects {
-			t.Logf("Expected %d dependencies but received %d",
+			t.Fatalf("Expected %d dependencies but received %d",
 				test.expectedDirect, len(modFile.Indirect))
-			t.Fail()
+		}
+	}
+}
+
+func TestReplace(t *testing.T) {
+	data, err := GoModBytes(filepath.Join("testdata", "replace.go.mod"))
+	if err != nil {
+		t.Log(err)
+		t.Fail()
+	}
+
+	modFile, err := Parse(data)
+	if err != nil {
+		t.Log(err)
+		t.Fail()
+	}
+
+	expected := []*Module{
+		{
+			Path:    "example.com/fork/net",
+			Version: "v1.4.5",
+		},
+		{
+			Path:    "example.com/fork/http",
+			Version: "v1.19.0",
+		},
+		{
+			Path:    "example.com/fork/http",
+			Version: "v1.19.0",
+		},
+	}
+
+	for _, e := range expected {
+		var found bool
+		for _, d := range modFile.Direct {
+			if e.Path == d.Path && e.Version == d.Version {
+				found = true
+				continue
+			}
+		}
+
+		if found != true {
+			t.Log("Modfile parsed from testdata:")
+			for i, d := range modFile.Direct {
+				t.Logf("[%d] path: %s version %s", i, d.Path, d.Version)
+			}
+			t.Fatalf("expected path: %s and version: %s but missing from parsed mod file", e.Path, e.Version)
 		}
 	}
 }

--- a/modfile_test.go
+++ b/modfile_test.go
@@ -88,7 +88,7 @@ func TestReplace(t *testing.T) {
 			for i, d := range modFile.Direct {
 				t.Logf("[%d] path: %s version %s", i, d.Path, d.Version)
 			}
-			t.Fatalf("expected path: %s and version: %s but missing from parsed mod file", e.Path, e.Version)
+			t.Fatalf("expected path: %s, version: %s not found", e.Path, e.Version)
 		}
 	}
 }

--- a/testdata/replace.go.mod
+++ b/testdata/replace.go.mod
@@ -1,0 +1,12 @@
+module replace
+
+go 1.19
+
+require (
+	golang.org/x/net v1.2.3
+    golang.org/x/http v1.2.1
+    golang.org/x/http v1.3.4
+)
+
+replace golang.org/x/net v1.2.3 => example.com/fork/net v1.4.5
+replace golang.org/x/http => example.com/fork/http v1.19.0

--- a/testdata/simple.go.mod
+++ b/testdata/simple.go.mod
@@ -1,0 +1,15 @@
+module simple
+
+go 1.19
+
+require (
+	cloud.google.com/go/bigquery v1.42.0
+	cloud.google.com/go/monitoring v1.5.0
+	cloud.google.com/go/pubsub v1.25.1
+	cloud.google.com/go/storage v1.23.0
+	collectd.org v0.5.0
+)
+
+require (
+	gopkg.in/httprequest.v1 v1.2.1 // indirect
+)

--- a/testdata/telegraf.go.mod
+++ b/testdata/telegraf.go.mod
@@ -1,0 +1,437 @@
+module github.com/influxdata/telegraf
+
+go 1.19
+
+require (
+	cloud.google.com/go/bigquery v1.42.0
+	cloud.google.com/go/monitoring v1.5.0
+	cloud.google.com/go/pubsub v1.25.1
+	cloud.google.com/go/storage v1.23.0
+	collectd.org v0.5.0
+	github.com/Azure/azure-event-hubs-go/v3 v3.3.18
+	github.com/Azure/azure-kusto-go v0.8.0
+	github.com/Azure/azure-storage-queue-go v0.0.0-20191125232315-636801874cdd
+	github.com/Azure/go-autorest/autorest v0.11.28
+	github.com/Azure/go-autorest/autorest/adal v0.9.21
+	github.com/Azure/go-autorest/autorest/azure/auth v0.5.11
+	github.com/BurntSushi/toml v1.2.0
+	github.com/ClickHouse/clickhouse-go v1.5.4
+	github.com/DATA-DOG/go-sqlmock v1.5.0
+	github.com/Masterminds/sprig v2.22.0+incompatible
+	github.com/Mellanox/rdmamap v0.0.0-20191106181932-7c3c4763a6ee
+	github.com/Shopify/sarama v1.37.2
+	github.com/aerospike/aerospike-client-go/v5 v5.10.0
+	github.com/alecthomas/units v0.0.0-20210208195552-ff826a37aa15
+	github.com/aliyun/alibaba-cloud-sdk-go v1.61.1818
+	github.com/amir/raidman v0.0.0-20170415203553-1ccc43bfb9c9
+	github.com/antchfx/jsonquery v1.3.0
+	github.com/antchfx/xmlquery v1.3.12
+	github.com/antchfx/xpath v1.2.1
+	github.com/apache/iotdb-client-go v0.12.2-0.20220722111104-cd17da295b46
+	github.com/apache/thrift v0.16.0
+	github.com/aristanetworks/goarista v0.0.0-20190325233358-a123909ec740
+	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
+	github.com/aws/aws-sdk-go-v2 v1.17.1
+	github.com/aws/aws-sdk-go-v2/config v1.17.8
+	github.com/aws/aws-sdk-go-v2/credentials v1.12.21
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.17
+	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.21.6
+	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.15.13
+	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.17.3
+	github.com/aws/aws-sdk-go-v2/service/ec2 v1.54.4
+	github.com/aws/aws-sdk-go-v2/service/kinesis v1.15.19
+	github.com/aws/aws-sdk-go-v2/service/sts v1.16.19
+	github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.13.12
+	github.com/aws/smithy-go v1.13.4
+	github.com/benbjohnson/clock v1.3.0
+	github.com/blues/jsonata-go v1.5.4
+	github.com/bmatcuk/doublestar/v3 v3.0.0
+	github.com/caio/go-tdigest v3.1.0+incompatible
+	github.com/cisco-ie/nx-telemetry-proto v0.0.0-20220628142927-f4160bcb943c
+	github.com/coocood/freecache v1.2.2
+	github.com/coreos/go-semver v0.3.0
+	github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f
+	github.com/couchbase/go-couchbase v0.1.1
+	github.com/denisenkom/go-mssqldb v0.12.0
+	github.com/digitalocean/go-libvirt v0.0.0-20220811165305-15feff002086
+	github.com/dimchansky/utfbom v1.1.1
+	github.com/djherbis/times v1.5.0
+	github.com/docker/docker v20.10.17+incompatible
+	github.com/docker/go-connections v0.4.0
+	github.com/doclambda/protobufquery v0.0.0-20220727165953-0da287796ee9
+	github.com/dynatrace-oss/dynatrace-metric-utils-go v0.5.0
+	github.com/eclipse/paho.golang v0.10.0
+	github.com/eclipse/paho.mqtt.golang v1.4.1
+	github.com/fatih/color v1.13.0
+	github.com/go-ldap/ldap/v3 v3.4.4
+	github.com/go-logfmt/logfmt v0.5.1
+	github.com/go-redis/redis/v7 v7.4.1
+	github.com/go-redis/redis/v8 v8.11.5
+	github.com/go-sql-driver/mysql v1.6.0
+	github.com/go-stomp/stomp v2.1.4+incompatible
+	github.com/gobwas/glob v0.2.3
+	github.com/gofrs/uuid v4.3.0+incompatible
+	github.com/golang-jwt/jwt/v4 v4.4.2
+	github.com/golang/geo v0.0.0-20190916061304-5b978397cfec
+	github.com/golang/snappy v0.0.4
+	github.com/google/gnxi v0.0.0-20220411075422-cd6b043b7fd0
+	github.com/google/go-cmp v0.5.9
+	github.com/google/go-github/v32 v32.1.0
+	github.com/google/licensecheck v0.3.1
+	github.com/google/uuid v1.3.0
+	github.com/gopcua/opcua v0.3.7
+	github.com/gophercloud/gophercloud v1.0.0
+	github.com/gorilla/mux v1.8.0
+	github.com/gorilla/websocket v1.5.0
+	github.com/gosnmp/gosnmp v1.34.0
+	github.com/grid-x/modbus v0.0.0-20211113184042-7f2251c342c9
+	github.com/gwos/tcg/sdk v0.0.0-20220621192633-df0eac0a1a4c
+	github.com/harlow/kinesis-consumer v0.3.6-0.20211204214318-c2b9f79d7ab6
+	github.com/hashicorp/consul/api v1.15.2
+	github.com/hashicorp/go-uuid v1.0.3
+	github.com/influxdata/go-syslog/v3 v3.0.0
+	github.com/influxdata/influxdb-observability/common v0.2.30
+	github.com/influxdata/influxdb-observability/influx2otel v0.2.30
+	github.com/influxdata/influxdb-observability/otel2influx v0.2.30
+	github.com/influxdata/line-protocol/v2 v2.2.1
+	github.com/influxdata/tail v1.0.1-0.20210707231403-b283181d1fa7
+	github.com/influxdata/toml v0.0.0-20190415235208-270119a8ce65
+	github.com/influxdata/wlog v0.0.0-20160411224016-7c63b0a71ef8
+	github.com/intel/iaevents v1.0.0
+	github.com/jackc/pgconn v1.13.0
+	github.com/jackc/pgio v1.0.0
+	github.com/jackc/pgtype v1.12.0
+	github.com/jackc/pgx/v4 v4.17.1
+	github.com/james4k/rcon v0.0.0-20120923215419-8fbb8268b60a
+	github.com/jhump/protoreflect v1.8.3-0.20210616212123-6cc1efa697ca
+	github.com/jmespath/go-jmespath v0.4.0
+	github.com/kardianos/service v1.2.1
+	github.com/karrick/godirwalk v1.17.0
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
+	github.com/kolo/xmlrpc v0.0.0-20201022064351-38db28db192b
+	github.com/lxc/lxd v0.0.0-20220920163450-e9b4b514106a
+	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
+	github.com/mdlayher/apcupsd v0.0.0-20220319200143-473c7b5f3c6a
+	github.com/microsoft/ApplicationInsights-Go v0.4.4
+	github.com/miekg/dns v1.1.50
+	github.com/moby/ipvs v1.0.2
+	github.com/multiplay/go-ts3 v1.0.1
+	github.com/nats-io/nats-server/v2 v2.8.4
+	github.com/nats-io/nats.go v1.17.0
+	github.com/newrelic/newrelic-telemetry-sdk-go v0.8.1
+	github.com/nsqio/go-nsq v1.1.0
+	github.com/olivere/elastic v6.2.37+incompatible
+	github.com/openconfig/gnmi v0.0.0-20200617225440-d2b4e6a45802
+	github.com/opentracing/opentracing-go v1.2.0
+	github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5
+	github.com/openzipkin/zipkin-go v0.2.5
+	github.com/pborman/ansi v1.0.0
+	github.com/pion/dtls/v2 v2.1.5
+	github.com/pkg/errors v0.9.1
+	github.com/prometheus-community/pro-bing v0.1.0
+	github.com/prometheus/client_golang v1.13.0
+	github.com/prometheus/client_model v0.3.0
+	github.com/prometheus/common v0.37.0
+	github.com/prometheus/procfs v0.8.0
+	github.com/prometheus/prometheus v1.8.2-0.20210430082741-2a4b8e12bbf2
+	github.com/rabbitmq/amqp091-go v1.5.0
+	github.com/riemann/riemann-go-client v0.5.1-0.20211206220514-f58f10cdce16
+	github.com/robbiet480/go.nut v0.0.0-20220219091450-bd8f121e1fa1
+	github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1
+	github.com/sensu/sensu-go/api/core/v2 v2.15.0
+	github.com/shirou/gopsutil/v3 v3.22.9
+	github.com/showwin/speedtest-go v1.1.5
+	github.com/signalfx/golib/v3 v3.3.46
+	github.com/sirupsen/logrus v1.9.0
+	github.com/sleepinggenius2/gosmi v0.4.4
+	github.com/snowflakedb/gosnowflake v1.6.13
+	github.com/stretchr/testify v1.8.1
+	github.com/tbrandon/mbserver v0.0.0-20170611213546-993e1772cc62
+	github.com/testcontainers/testcontainers-go v0.14.0
+	github.com/thomasklein94/packer-plugin-libvirt v0.3.4
+	github.com/tidwall/gjson v1.14.3
+	github.com/tinylib/msgp v1.1.6
+	github.com/urfave/cli/v2 v2.16.3
+	github.com/vapourismo/knx-go v0.0.0-20220829185957-fb5458a5389d
+	github.com/vjeantet/grok v1.0.1
+	github.com/vmware/govmomi v0.28.1-0.20220921224932-b4b508abf208
+	github.com/wavefronthq/wavefront-sdk-go v0.10.4
+	github.com/wvanbergen/kafka v0.0.0-20171203153745-e2edea948ddf
+	github.com/xdg/scram v1.0.5
+	github.com/yuin/goldmark v1.5.2
+	go.mongodb.org/mongo-driver v1.10.2
+	go.opentelemetry.io/collector/pdata v0.63.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v0.32.1
+	go.opentelemetry.io/otel/sdk/metric v0.32.1
+	go.starlark.net v0.0.0-20220328144851-d1966c6b9fcd
+	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
+	golang.org/x/net v0.0.0-20221014081412-f15817d10f9b
+	golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783
+	golang.org/x/sync v0.0.0-20220929204114-8fcdb60fdcc0
+	golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8
+	golang.org/x/text v0.3.7
+	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20211230205640-daad0b7ba671
+	gonum.org/v1/gonum v0.12.0
+	google.golang.org/api v0.100.0
+	google.golang.org/genproto v0.0.0-20221014213838-99cd37c6964a
+	google.golang.org/grpc v1.50.1
+	google.golang.org/protobuf v1.28.1
+	gopkg.in/gorethink/gorethink.v3 v3.0.5
+	gopkg.in/olivere/elastic.v5 v5.0.86
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
+	gopkg.in/yaml.v2 v2.4.0
+	k8s.io/api v0.25.3
+	k8s.io/apimachinery v0.25.3
+	k8s.io/client-go v0.25.0
+	modernc.org/sqlite v1.19.2
+)
+
+require (
+	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.13.6 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.0 // indirect
+	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
+	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
+	go.opentelemetry.io/otel/metric v0.32.1 // indirect
+	go.uber.org/zap v1.22.0 // indirect
+)
+
+require (
+	cloud.google.com/go v0.104.0 // indirect
+	cloud.google.com/go/compute v1.10.0 // indirect
+	cloud.google.com/go/iam v0.3.0 // indirect
+	code.cloudfoundry.org/clock v1.0.0 // indirect
+	github.com/Azure/azure-amqp-common-go/v3 v3.2.3 // indirect
+	github.com/Azure/azure-pipeline-go v0.2.3 // indirect
+	github.com/Azure/azure-sdk-for-go v61.2.0+incompatible // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.3.0 // indirect
+	github.com/Azure/azure-storage-blob-go v0.14.0 // indirect
+	github.com/Azure/go-amqp v0.17.0 // indirect
+	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
+	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
+	github.com/Azure/go-autorest/autorest/azure/cli v0.4.5 // indirect
+	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
+	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
+	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect
+	github.com/Azure/go-autorest/logger v0.2.1 // indirect
+	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
+	github.com/Azure/go-ntlmssp v0.0.0-20220621081337-cb9428e4ac1e // indirect
+	github.com/Masterminds/goutils v1.1.1 // indirect
+	github.com/Masterminds/semver v1.5.0 // indirect
+	github.com/Microsoft/go-winio v0.5.2 // indirect
+	github.com/Microsoft/hcsshim v0.9.4 // indirect
+	github.com/alecthomas/participle v0.4.1 // indirect
+	github.com/apache/arrow/go/arrow v0.0.0-20211112161151-bc219186db40 // indirect
+	github.com/aristanetworks/glog v0.0.0-20191112221043-67e8567f59f3 // indirect
+	github.com/armon/go-metrics v0.3.10 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.8 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.2.0 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.7.1 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.25 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.19 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.24 // indirect
+	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.4.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.10 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.7.19 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.17 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.9.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.19.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sso v1.11.23 // indirect
+	github.com/awslabs/kinesis-aggregation/go v0.0.0-20210630091500-54e17340d32f // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bitly/go-hostpool v0.1.0 // indirect
+	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
+	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58 // indirect
+	github.com/containerd/cgroups v1.0.4 // indirect
+	github.com/containerd/containerd v1.6.8 // indirect
+	github.com/couchbase/gomemcached v0.1.3 // indirect
+	github.com/couchbase/goutils v0.1.0 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/devigned/tab v0.1.1 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/docker/distribution v2.8.1+incompatible // indirect
+	github.com/docker/go-units v0.5.0 // indirect
+	github.com/eapache/go-resiliency v1.3.0 // indirect
+	github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 // indirect
+	github.com/eapache/queue v1.1.0 // indirect
+	github.com/echlebek/timeproxy v1.0.0 // indirect
+	github.com/emicklei/go-restful/v3 v3.8.0 // indirect
+	github.com/flosch/pongo2 v0.0.0-20200913210552-0d938eb266f3 // indirect
+	github.com/form3tech-oss/jwt-go v3.2.5+incompatible // indirect
+	github.com/go-asn1-ber/asn1-ber v1.5.4 // indirect
+	github.com/go-logr/logr v1.2.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-macaroon-bakery/macaroonpb v1.0.0 // indirect
+	github.com/go-ole/go-ole v1.2.6 // indirect
+	github.com/go-openapi/jsonpointer v0.19.5 // indirect
+	github.com/go-openapi/jsonreference v0.20.0 // indirect
+	github.com/go-openapi/swag v0.22.1 // indirect
+	github.com/go-stack/stack v1.8.1 // indirect
+	github.com/goburrow/modbus v0.1.0 // indirect
+	github.com/goburrow/serial v0.1.1-0.20211022031912-bfb69110f8dd // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe // indirect
+	github.com/golang-sql/sqlexp v0.0.0-20170517235910-f1bb20e5a188 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/flatbuffers v2.0.0+incompatible // indirect
+	github.com/google/gnostic v0.5.7-v3refs // indirect
+	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/googleapis/enterprise-certificate-proxy v0.2.0 // indirect
+	github.com/googleapis/gax-go/v2 v2.6.0 // indirect
+	github.com/googleapis/go-type-adapters v1.0.0 // indirect
+	github.com/grid-x/serial v0.0.0-20211107191517-583c7356b3aa // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
+	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-hclog v1.2.2 // indirect
+	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/hashicorp/packer-plugin-sdk v0.3.1 // indirect
+	github.com/hashicorp/serf v0.9.7 // indirect
+	github.com/huandu/xstrings v1.3.2 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgproto3/v2 v2.3.1 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
+	github.com/jackc/puddle v1.3.0 // indirect
+	github.com/jaegertracing/jaeger v1.38.0 // indirect
+	github.com/jcmturner/aescts/v2 v2.0.0 // indirect
+	github.com/jcmturner/dnsutils/v2 v2.0.0 // indirect
+	github.com/jcmturner/gofork v1.7.6 // indirect
+	github.com/jcmturner/gokrb5/v8 v8.4.3 // indirect
+	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/josharian/native v1.0.0 // indirect
+	github.com/jpillora/backoff v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/juju/webbrowser v1.0.0 // indirect
+	github.com/julienschmidt/httprouter v1.3.0 // indirect
+	github.com/klauspost/compress v1.15.11 // indirect
+	github.com/kr/fs v0.1.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
+	github.com/leodido/ragel-machinery v0.0.0-20181214104525-299bdde78165 // indirect
+	github.com/lufia/plan9stats v0.0.0-20220913051719-115f729f3c8c // indirect
+	github.com/magiconair/properties v1.8.6 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-ieproxy v0.0.1 // indirect
+	github.com/mattn/go-isatty v0.0.16 // indirect
+	github.com/mdlayher/genetlink v1.2.0 // indirect
+	github.com/mdlayher/netlink v1.6.0 // indirect
+	github.com/mdlayher/socket v0.2.3 // indirect
+	github.com/minio/highwayhash v1.0.2 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/moby/sys/mount v0.3.3 // indirect
+	github.com/moby/sys/mountinfo v0.6.2 // indirect
+	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe // indirect
+	github.com/morikuni/aec v1.0.0 // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/naoina/go-stringutil v0.1.0 // indirect
+	github.com/nats-io/jwt/v2 v2.2.1-0.20220330180145-442af02fd36a // indirect
+	github.com/nats-io/nkeys v0.3.0 // indirect
+	github.com/nats-io/nuid v1.0.1 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799 // indirect
+	github.com/opencontainers/runc v1.1.3 // indirect
+	github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492 // indirect
+	github.com/pborman/uuid v1.2.1 // indirect
+	github.com/philhofer/fwd v1.1.1 // indirect
+	github.com/pierrec/lz4/v4 v4.1.17 // indirect
+	github.com/pion/logging v0.2.2 // indirect
+	github.com/pion/transport v0.13.0 // indirect
+	github.com/pion/udp v0.1.1 // indirect
+	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
+	github.com/pkg/sftp v1.13.5 // indirect
+	github.com/pkg/xattr v0.4.9 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/power-devops/perfstat v0.0.0-20220216144756-c35f1ee13d7c // indirect
+	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
+	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
+	github.com/robertkrimen/otto v0.0.0-20191219234010-c382bd3c16ff // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
+	github.com/rogpeppe/fastuuid v1.2.0 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/samuel/go-zookeeper v0.0.0-20200724154423-2164a8ac840e // indirect
+	github.com/signalfx/com_signalfx_metrics_protobuf v0.0.3 // indirect
+	github.com/signalfx/gohistogram v0.0.0-20160107210732-1ccfd2ff5083 // indirect
+	github.com/signalfx/sapm-proto v0.7.2 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
+	github.com/tklauser/go-sysconf v0.3.10 // indirect
+	github.com/tklauser/numcpus v0.5.0 // indirect
+	github.com/vishvananda/netlink v1.2.1-beta.2 // indirect
+	github.com/vishvananda/netns v0.0.0-20220913150850-18c4f4234207 // indirect
+	github.com/wvanbergen/kazoo-go v0.0.0-20180202103751-f72d8611297a // indirect
+	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
+	github.com/xdg-go/scram v1.1.1 // indirect
+	github.com/xdg-go/stringprep v1.0.3 // indirect
+	github.com/xdg/stringprep v1.0.3 // indirect
+	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
+	github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a // indirect
+	github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da // indirect
+	github.com/yusufpapurcu/wmi v1.2.2 // indirect
+	go.etcd.io/etcd/api/v3 v3.5.4 // indirect
+	go.opencensus.io v0.23.0 // indirect
+	go.opentelemetry.io/otel v1.10.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.10.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.32.1 // indirect
+	go.opentelemetry.io/otel/sdk v1.10.0 // indirect
+	go.opentelemetry.io/otel/trace v1.10.0 // indirect
+	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
+	go.uber.org/atomic v1.9.0 // indirect
+	go.uber.org/multierr v1.8.0 // indirect
+	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 // indirect
+	golang.org/x/exp v0.0.0-20200513190911-00229845015e // indirect
+	golang.org/x/term v0.0.0-20220722155259-a9ba230a4035 // indirect
+	golang.org/x/time v0.0.0-20220609170525-579cf78fd858 // indirect
+	golang.org/x/tools v0.1.12 // indirect
+	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
+	golang.zx2c4.com/wireguard v0.0.0-20211209221555-9c9e7e272434 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	gopkg.in/errgo.v1 v1.0.1 // indirect
+	gopkg.in/fatih/pool.v2 v2.0.0 // indirect
+	gopkg.in/fsnotify.v1 v1.4.7 // indirect
+	gopkg.in/httprequest.v1 v1.2.1 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/macaroon-bakery.v3 v3.0.0 // indirect
+	gopkg.in/macaroon.v2 v2.1.0 // indirect
+	gopkg.in/sourcemap.v1 v1.0.5 // indirect
+	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gotest.tools v2.2.0+incompatible
+	honnef.co/go/tools v0.2.2 // indirect
+	k8s.io/klog/v2 v2.70.1 // indirect
+	k8s.io/kube-openapi v0.0.0-20220803164354-a70c9af30aea // indirect
+	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed // indirect
+	lukechampine.com/uint128 v1.2.0 // indirect
+	modernc.org/cc/v3 v3.40.0 // indirect
+	modernc.org/ccgo/v3 v3.16.13-0.20221017192402-261537637ce8 // indirect
+	modernc.org/libc v1.21.2 // indirect
+	modernc.org/mathutil v1.5.0 // indirect
+	modernc.org/memory v1.4.0 // indirect
+	modernc.org/opt v0.1.3 // indirect
+	modernc.org/strutil v1.1.3 // indirect
+	modernc.org/token v1.0.1 // indirect
+	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
+)

--- a/verify.go
+++ b/verify.go
@@ -1,0 +1,13 @@
+package gograveyard
+
+import (
+	"regexp"
+	"strings"
+)
+
+// VerifySemanticVersion based on the recommended regex: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+func VerifySemanticVersion(ver string) bool {
+	ver = strings.TrimPrefix(ver, "v")
+	match, _ := regexp.MatchString(`^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`, ver)
+	return match
+}

--- a/verify.go
+++ b/verify.go
@@ -6,6 +6,8 @@ import (
 )
 
 // VerifySemanticVersion based on the recommended regex: https://semver.org
+//
+//nolint:lll // Exception to use recommended regex
 func VerifySemanticVersion(ver string) bool {
 	ver = strings.TrimPrefix(ver, "v")
 	match, _ := regexp.MatchString(`^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`, ver)

--- a/verify.go
+++ b/verify.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-// VerifySemanticVersion based on the recommended regex: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+// VerifySemanticVersion based on the recommended regex: https://semver.org
 func VerifySemanticVersion(ver string) bool {
 	ver = strings.TrimPrefix(ver, "v")
 	match, _ := regexp.MatchString(`^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`, ver)


### PR DESCRIPTION
resolve: https://github.com/goreapers/gograveyard/issues/12

Added a function `Parse` to take a byte array from a `go.mod` file and parse it into a struct that contains slices of all the modules. The module is defined by the path, version and categorized if it is indirect or not.