### PR TITLE
feat: Get open issue count

### DIFF
--- a/github.go
+++ b/github.go
@@ -1,6 +1,7 @@
 package gograveyard
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -16,30 +17,39 @@ type Project struct {
 }
 
 type SearchIssues struct {
-	TotalCount int `json:"total_count"`
+	TotalCount int `json:"total_count"` //nolint:tagliatelle
 }
 
 // OpenIssueCount will return the number of open issues for a repository
-// This API endpoint used was found here: https://github.com/isaacs/github/issues/536#issuecomment-532884919
+// This API endpoint used was found here:
+// https://github.com/isaacs/github/issues/536#issuecomment-532884919
 func (p Project) OpenIssuesCount() (int, error) {
 	var count int
 
-	resp, err := p.Client.Get(fmt.Sprintf("%s/search/issues?q=repo:%s/%s+type:issue+state:open&per_page=1", BaseURL, p.Owner, p.Repo))
+	url := fmt.Sprintf("%s/search/issues?q=repo:%s/%s+type:issue+state:open&per_page=1",
+		BaseURL, p.Owner, p.Repo)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
 	if err != nil {
-		return count, err
+		return count, fmt.Errorf("failed to create new request with context: %w", err)
+	}
+
+	resp, err := p.Client.Do(req)
+	if err != nil {
+		return count, fmt.Errorf("http GET failed for open issue count: %w", err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return count, err
+		return count, fmt.Errorf("failed to read response body: %w", err)
 	}
 
 	var s SearchIssues
 
 	err = json.Unmarshal(body, &s)
 	if err != nil {
-		return count, err
+		return count, fmt.Errorf("failed to unmarshal open issue count: %w", err)
 	}
 
 	return s.TotalCount, nil

--- a/github.go
+++ b/github.go
@@ -1,0 +1,46 @@
+package gograveyard
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const BaseURL = "https://api.github.com"
+
+type Project struct {
+	Client *http.Client
+	Owner  string
+	Repo   string
+}
+
+type SearchIssues struct {
+	TotalCount int `json:"total_count"`
+}
+
+// OpenIssueCount will return the number of open issues for a repository
+// This API endpoint used was found here: https://github.com/isaacs/github/issues/536#issuecomment-532884919
+func (p Project) OpenIssuesCount() (int, error) {
+	var count int
+
+	resp, err := p.Client.Get(fmt.Sprintf("%s/search/issues?q=repo:%s/%s+type:issue+state:open&per_page=1", BaseURL, p.Owner, p.Repo))
+	if err != nil {
+		return count, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return count, err
+	}
+
+	var s SearchIssues
+
+	err = json.Unmarshal(body, &s)
+	if err != nil {
+		return count, err
+	}
+
+	return s.TotalCount, nil
+}

--- a/github_test.go
+++ b/github_test.go
@@ -1,0 +1,58 @@
+package gograveyard
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+type RoundTripFunc func(req *http.Request) *http.Response
+
+func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req), nil
+}
+
+// NewTestClient returns *http.Client with Transport replaced to avoid making real calls
+func NewTestClient(fn RoundTripFunc) *http.Client {
+	return &http.Client{
+		Transport: RoundTripFunc(fn),
+	}
+}
+
+func TestOpenIssuesCount(t *testing.T) {
+	expectedCount := 2
+
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		s := SearchIssues{
+			TotalCount: expectedCount,
+		}
+		b, err := json.Marshal(s)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return &http.Response{
+			StatusCode: 200,
+			// Send response to be tested
+			Body: ioutil.NopCloser(bytes.NewBuffer(b)),
+			// Must be set to non-nil value or it panics
+			Header: make(http.Header),
+		}
+	})
+
+	p := Project{
+		client,
+		"goreapers",
+		"gograveyard",
+	}
+	c, err := p.OpenIssuesCount()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if c != expectedCount {
+		t.Fatalf("Expected issue count %d but got %d", 2, c)
+	}
+}


### PR DESCRIPTION
Partially implements: https://github.com/goreapers/gograveyard/issues/6

Added a struct `Project` that has a method `OpenIssuesCount` that will execute a get request against the github search API to get the total open issue count for a repository.